### PR TITLE
Fix "Login in with" typo

### DIFF
--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/ProviderButton.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/ProviderButton.kt
@@ -44,8 +44,8 @@ fun ProviderIcon(provider: OAuthProvider, contentDescription: String?, modifier:
  */
 @SupabaseExperimental
 @Composable
-fun RowScope.ProviderButtonContent(provider: OAuthProvider, text: String = "Login in with ${provider.name.capitalize()}") {
-    ProviderIcon(provider, "Login in with ${provider.name}", Modifier.size(DEFAULT_ICON_SIZE))
+fun RowScope.ProviderButtonContent(provider: OAuthProvider, text: String = "Login with ${provider.name.capitalize()}") {
+    ProviderIcon(provider, "Login with ${provider.name}", Modifier.size(DEFAULT_ICON_SIZE))
     Spacer(Modifier.width(8.dp))
     Text(text)
 }


### PR DESCRIPTION
"Login in with" -> "Login with"

Typo:
<img width="429" alt="image" src="https://github.com/JOsacky/supabase-kt/assets/1144450/a45d0262-281b-45a4-aebd-34883786dc8f">
